### PR TITLE
GO should not solve when jail is active

### DIFF
--- a/Assets/FreeParkingScript.cs
+++ b/Assets/FreeParkingScript.cs
@@ -289,10 +289,11 @@ public class FreeParkingScript : MonoBehaviour
             Debug.LogFormat("[Free Parking #{0}] Strike! You tried to pass GO! when you should be going to jail.", moduleId);
             GetComponent<KMBombModule>().HandleStrike();
             FreeParkingEtc();
+            return;
         }
-        if(baseMoneyInt > 5000)
+        moduloMoney = baseMoneyInt;
+        if (baseMoneyInt > 5000)
         {
-            moduloMoney = baseMoneyInt;
             baseMoneyInt = baseMoneyInt % 5000;
             Debug.LogFormat("[Free Parking #{0}] The value at submission was greater than $5000. Modulo 5000. The new value is ${1}.", moduleId, baseMoneyInt);
         }


### PR DESCRIPTION
- Return the GO method if it's pressed when the pressJail condition is true.
- Move moduloMoney outside of the condition so that it does not have the default value of 0 when baseMoneyInt is less than 5000.